### PR TITLE
Fix Catalogues points to a wrong url

### DIFF
--- a/catalogs.go
+++ b/catalogs.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	pathCatalogs = "/portal-api/catalogs"
-	pathCatalog  = "/portal-api/catalogs/%d"
+	pathCatalogs = "/portal-api/catalogues"
+	pathCatalog  = "/portal-api/catalogues/%d"
 )
 
 //go:generate mockery --name Catalogs --filename catalogs.go


### PR DESCRIPTION
Fix issue #27 
Catalogues pointed to `/portal-api/catalogs` and it should be `/portal-api/catalogues`