### PR TITLE
Fix error parsing date when getting AR details

### DIFF
--- a/ars.go
+++ b/ars.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 )
 
 const (
@@ -157,21 +156,21 @@ type ARSummary struct {
 }
 
 type Credentials struct {
-	AccessRequest              string    `json:"AccessRequest,omitempty"`
-	Credential                 string    `json:"Credential,omitempty"`
-	CredentialHash             string    `json:"CredentialHash,omitempty"`
-	DCRRegistrationAccessToken string    `json:"DCRRegistrationAccessToken,omitempty"`
-	DCRRegistrationClientURI   string    `json:"DCRRegistrationClientURI,omitempty"`
-	DCRResponse                string    `json:"DCRResponse,omitempty"`
-	Expires                    time.Time `json:"Expires,omitempty"`
-	OAuthClientID              string    `json:"OAuthClientID,omitempty"`
-	OAuthClientSecret          string    `json:"OAuthClientSecret,omitempty"`
-	RedirectURI                string    `json:"RedirectURI,omitempty"`
-	ResponseType               string    `json:"ResponseType,omitempty"`
-	Scope                      string    `json:"Scope,omitempty"`
-	TokenEndpoints             string    `json:"TokenEndpoints,omitempty"`
-	GrantType                  *string   `json:"GrantType,omitempty"`
-	ID                         *int64    `json:"ID,omitempty"`
+	AccessRequest              string     `json:"AccessRequest,omitempty"`
+	Credential                 string     `json:"Credential,omitempty"`
+	CredentialHash             string     `json:"CredentialHash,omitempty"`
+	DCRRegistrationAccessToken string     `json:"DCRRegistrationAccessToken,omitempty"`
+	DCRRegistrationClientURI   string     `json:"DCRRegistrationClientURI,omitempty"`
+	DCRResponse                string     `json:"DCRResponse,omitempty"`
+	Expires                    CustomTime `json:"Expires,omitempty"`
+	OAuthClientID              string     `json:"OAuthClientID,omitempty"`
+	OAuthClientSecret          string     `json:"OAuthClientSecret,omitempty"`
+	RedirectURI                string     `json:"RedirectURI,omitempty"`
+	ResponseType               string     `json:"ResponseType,omitempty"`
+	Scope                      string     `json:"Scope,omitempty"`
+	TokenEndpoints             string     `json:"TokenEndpoints,omitempty"`
+	GrantType                  *string    `json:"GrantType,omitempty"`
+	ID                         *int64     `json:"ID,omitempty"`
 }
 
 type ListARsOutput struct {

--- a/custom-time.go
+++ b/custom-time.go
@@ -24,6 +24,6 @@ func (ct *CustomTime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (ct *CustomTime) MarshalJSON() ([]byte, error) {
-	return []byte(ct.Time.Format("2006-01-02 15:04")), nil
+func (ct *CustomTime) MarshalJSON() []byte {
+	return []byte(ct.Time.Format("2006-01-02 15:04"))
 }

--- a/custom-time.go
+++ b/custom-time.go
@@ -1,0 +1,29 @@
+package portal
+
+import (
+	"strings"
+	"time"
+)
+
+type CustomTime struct {
+	time.Time
+}
+
+func (ct *CustomTime) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		return nil
+	}
+
+	t, err := time.Parse("2006-01-02 15:04", s)
+	if err != nil {
+		return err
+	}
+
+	ct.Time = t
+	return nil
+}
+
+func (ct *CustomTime) MarshalJSON() ([]byte, error) {
+	return []byte(ct.Time.Format("2006-01-02 15:04")), nil
+}

--- a/custom-time_test.go
+++ b/custom-time_test.go
@@ -1,0 +1,72 @@
+package portal
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCustomTime_UnmarshalJSON(t *testing.T) {
+	var (
+		t0, _ = time.Parse("2006-01-02 15:04", "2020-01-01 00:00")
+	)
+	tests := []struct {
+		name    string
+		Time    time.Time
+		b       []byte
+		wantErr bool
+	}{
+		{
+			name:    "Success",
+			Time:    t0,
+			b:       []byte("2020-01-01 00:00"),
+			wantErr: false,
+		},
+		{
+			name:    "Null-value",
+			Time:    t0,
+			b:       []byte("null"),
+			wantErr: false,
+		},
+		{
+			name:    "Fail",
+			Time:    t0,
+			b:       []byte("2020-01-01T00:00:00Z00:00"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ct := &CustomTime{
+				Time: tt.Time,
+			}
+			if err := ct.UnmarshalJSON(tt.b); (err != nil) != tt.wantErr {
+				t.Errorf("CustomTime.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCustomTime_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		time time.Time
+		want []byte
+	}{
+		{
+			name: "Success",
+			time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			want: []byte("2020-01-01 00:00"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ct := &CustomTime{
+				Time: tt.time,
+			}
+			got := ct.MarshalJSON()
+			if string(got) != string(tt.want) {
+				t.Errorf("CustomTime.MarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix issue #29 
Error parsing date when getting an AR detail

```bash
$ bin/portal ar list
ID  USER    PLAN       PRODUCTS        STATUS    CLIENT  PROVISION IMMEDIATELY  DCR    CREATED AT        CATALOG  AUTH TYPE
1   User#8  free_plan  public_product  approved  app     false                  false  2023-08-09 21:15           authToken
$ bin/portal ar get 1
parsing time "2023-08-09 22:16" as "2006-01-02T15:04:05Z07:00": cannot parse " 22:16" as "T"
```

The error happens because the date recovered from the API is not in RFC 3339 format, but instead it's in `2006-01-02 15:04` format